### PR TITLE
Support for "text/x-vcard; charset=utf-8" as a value for getcontenttype

### DIFF
--- a/pycarddav/carddav.py
+++ b/pycarddav/carddav.py
@@ -273,7 +273,8 @@ class PyCardDAV(object):
                         for props in prop.iterchildren():
                             if (props.tag == namespace + "getcontenttype" and
                                 (props.text == "text/vcard" or
-                                 props.text == "text/x-vcard")):
+                                 props.text == "text/x-vcard" or
+                                 props.text == "text/x-vcard; charset=utf-8")):
                                 insert = True
                             if (props.tag == namespace + "getetag"):
                                 etag = props.text


### PR DESCRIPTION
I tried to use pycaldav with the Baïkal carddav server. Initially I couldn't get any vcard. Debugging a bit revealed Baïkal returns "text/x-vcard; charset=utf-8" as a value for getcontenttype.

This branch adds this new value to the accepted ones, it may need to be smarter though, as maybe other servers will return a slightly different type (quoting "utf-8" or something like that)
