### PR TITLE
Do not fail if FN is empty

### DIFF
--- a/pycarddav/model.py
+++ b/pycarddav/model.py
@@ -190,7 +190,7 @@ class VCard(defaultdict):
 
     @property
     def fname(self):
-        return unicode(self['FN'][0][0])
+        return unicode(self['FN'][0][0]) if self['FN'] else ''
 
     @fname.setter
     def fname(self, value):


### PR DESCRIPTION
One of the entries of my addressbook had an empty FN field, causing the import to fail. This simple workaround does the same thing as what is currently done for the N field.
