### PR TITLE
Use python2 as a default interpreter.

### DIFF
--- a/bin/pc_query
+++ b/bin/pc_query
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/bin/pycard-import
+++ b/bin/pycard-import
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors

--- a/bin/pycardsyncer
+++ b/bin/pycardsyncer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # vim: set fileencoding=utf-8 :
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/pycarddav/backend.py
+++ b/pycarddav/backend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/pycarddav/carddav.py
+++ b/pycarddav/carddav.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/pycarddav/controllers.py
+++ b/pycarddav/controllers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors

--- a/pycarddav/model.py
+++ b/pycarddav/model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/pycarddav/ui.py
+++ b/pycarddav/ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set ts=4 sw=4 expandtab sts=4:
 # Copyright (c) 2011-2013 Christian Geier & contributors
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 #from distutils.core import setup

--- a/tests/local/pycard_test.py
+++ b/tests/local/pycard_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # vim: set fileencoding=utf-8 :
 import pycarddav.model
 import os.path

--- a/tests/vagrant/test_carddav.py
+++ b/tests/vagrant/test_carddav.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # vim: set fileencoding=utf-8 :
 import vagrant
 import pytest


### PR DESCRIPTION
In accordance with PEP-394, python2 scripts should use `python2` as an interpreter. This ensures compatibility with setups that use python3 as a default, while retaining compatibility with distributions that still ship python2 as a default and comply with PEP-394.

I've tested these changes on ArchLinux, using python3 as a default (which is what Arch ships by default), and then again by setting python2 as a default. Nothing seems to have broken, and this works as-is with python3 set as a default (ie: it still uses python2).
