### PR TITLE
Change default for 'verify' to a bool, not a str.

### DIFF
--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -160,7 +160,7 @@ class AccountSection(Section):
             ('passwd', '', None),
             ('resource', '', None),
             ('auth', 'basic', None),
-            ('verify', 'True', self._parse_bool_string),
+            ('verify', True, self._parse_bool_string),
             ('write_support', '', self._parse_write_support),
         ]
 


### PR DESCRIPTION
In the AccountSection Class, the default for 'verify' option is set to
'True' which is a str type. It should be True which is a bool. If
'verify' is not set in the config file, the str 'True' will be used and
pass to the requests module. The consequence will be an SSL error as the
'True' string will be used as certificate location.
