### PR TITLE
Expose the PyCardDAV, so this can be used as a carddav library.

### DIFF
--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -21,6 +21,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from carddav import PyCardDAV
+
 import argparse
 import ConfigParser
 import getpass


### PR DESCRIPTION
This tiny change allows other to use `from pycarddav import PyCardDAV`, and reuse PyCardDAV as a library for other applications.
