### PR TITLE
Basic keyring support

### DIFF
--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -307,8 +307,14 @@ class ConfigurationParser(object):
                                   ns.user, hostname)
                     result = False
             elif ns.user:
+                try:
+                    import keyring
+                except ImportError:
+                    pass
+                else:
+                    ns.passwd = keyring.get_password('pycarddav:'+ns.name, ns.user)
                 # Do not ask for password if execution is already doomed.
-                if result:
+                if result and not ns.passwd:
                     prompt = 'CardDAV password (account ' + ns.name + '): '
                     ns.passwd = getpass.getpass(prompt=prompt)
             else:


### PR DESCRIPTION
This patch adds very basic keyring (gnome etc.) support. It uses `pycarddav:$account` instead of the full resource URL for usability.

Requires keyring: https://pypi.python.org/pypi/keyring

To set the password, run:

```
keyring set pycarddav:$account $username
```

Ref: #13
