### PR TITLE
Basic keyring support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,3 +5,4 @@ Hugo Osvaldo Barrera <hugo@osvaldobarrera.com.ar>
 Ben Boeckel - mathstuf [at] gmail [dot] com
 Thomas Glanzmann - thomas@glanzmann.de - http://thomas.glanzmann.de
 Johannes Goetzfried - johannes@jgoetzfried.de - http://jgoetzfried.de
+Steven Allen <steven@stebalien.com> - http://stebalien.com

--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -307,8 +307,14 @@ class ConfigurationParser(object):
                                   ns.user, hostname)
                     result = False
             elif ns.user:
+                try:
+                    import keyring
+                except ImportError:
+                    pass
+                else:
+                    ns.passwd = keyring.get_password('pycarddav:'+ns.name, ns.user)
                 # Do not ask for password if execution is already doomed.
-                if result:
+                if result and not ns.passwd:
                     prompt = 'CardDAV password (account ' + ns.name + '): '
                     ns.passwd = getpass.getpass(prompt=prompt)
             else:


### PR DESCRIPTION
This patch adds very basic keyring (gnome etc.) support. It uses `pycarddav:$account` instead of the full resource URL for usability.

Requires keyring: https://pypi.python.org/pypi/keyring

To set the password, run:

```
keyring set pycarddav:$account $username
```

Ref: #13
