### PR TITLE
activate PyOpenSSL if available

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,3 +9,4 @@ Steven Allen <steven@stebalien.com> - http://stebalien.com
 Jamie McClelland - jm@mayfirstorg - http://current.workingdirectory.net
 Leandro Lucarella - luca@llucax.com.ar - http://www.llucax.com.ar/
 Tobias Röttger - toroettg@gmail.com - http://www.roettger-it.de/
+Travis Parker - travis.parker@gmail.com

--- a/pycarddav/carddav.py
+++ b/pycarddav/carddav.py
@@ -77,6 +77,14 @@ class PyCardDAV(object):
         urllog = logging.getLogger('urllib3.connectionpool')
         urllog.setLevel(logging.CRITICAL)
 
+        # activate pyopenssl if available
+        try:
+            import urllib3.contrib.pyopenssl
+        except ImportError:
+            pass
+        else:
+            urllib3.contrib.pyopenssl.inject_into_urllib3()
+
         split_url = urlparse.urlparse(resource)
         url_tuple = namedtuple('url', 'resource base path')
         self.url = url_tuple(resource,


### PR DESCRIPTION
this brings support for SNI to python 2.x for servers that need it, and
disables SSL/TLS compression (good for mitigating CRIME)

also requires ndg-httpsclient and pyasn1

tested with python 2.7.8 against nginx 1.6 utilizing SNI (and where the
required certificate was not the first one presented)