### PR TITLE
Password lookup via shell command output

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -10,3 +10,4 @@ Jamie McClelland - jm@mayfirstorg - http://current.workingdirectory.net
 Leandro Lucarella - luca@llucax.com.ar - http://www.llucax.com.ar/
 Tobias Röttger - toroettg@gmail.com - http://www.roettger-it.de/
 Travis Parker - travis.parker@gmail.com
+Christian Burkert - post@cburkert.de

--- a/pycard.conf.sample
+++ b/pycard.conf.sample
@@ -5,6 +5,11 @@
 user: username
 passwd: yourpassword
 
+# A shell command line to read the password.
+# This can be used in instead of passwd to read a password from the standard output
+# of another program (e.g. a password manager). If passwd is set, this is ignored.
+#passwd_cmd: pass show carddav
+
 # The path to the CardDAV resource.
 #resource: https://[server]/owncloud/apps/contacts/carddav.php/addressbooks/[user]/[addressbook name]/
 resource: https://carddav.server.tld:443/davical/caldav.php/username/addresses/

--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -28,6 +28,7 @@ import re
 import logging
 import os
 import signal
+import subprocess
 import sys
 import xdg.BaseDirectory
 
@@ -163,6 +164,7 @@ class AccountSection(Section):
         self._schema = [
             ('user', '', None),
             ('passwd', '', None),
+            ('passwd_cmd', '', None),
             ('resource', '', None),
             ('auth', 'basic', None),
             ('verify', 'true', self._parse_verify),
@@ -321,6 +323,14 @@ class ConfigurationParser(object):
                 else:
                     logging.error("User %s not found for %s in .netrc",
                                   ns.user, hostname)
+                    result = False
+            elif ns.user and ns.passwd_cmd:
+                try:
+                    ns.passwd = subprocess.check_output(ns.passwd_cmd.split())
+                    ns.passwd = ns.passwd.strip() # strip trailing newline
+                except (OSError, subprocess.CalledProcessError) as e:
+                    logging.error("Failed to execute passwd command '%s'. Reason: %s",
+                            ns.passwd_cmd, e)
                     result = False
             elif ns.user:
                 try:


### PR DESCRIPTION
Recently, I started using pycarddav with mutt and since I'm happily using the password store *pass* to avoid writing plain passwords into config files (like muttrc), I wrote this patch to enable password lookups via shell command outputs.

This patch adds a new configuration variable called `passwd_cmd` that is simply a shell command.
If the user sets this variable in her config file, the specified command is executed and the standard output of this command is used as password for authentication.

It seemed to me, that the develop branch is no longer in use (behind master) so I make this PR to master. Please correct me if I am wrong.