### PR TITLE
Fix mutt example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ that query_command uses pc_query:
 
 Example from .muttrc::
 
-        set query_command="/home/username/bin/pc_query -m '%s'"
+        set query_command="/home/username/bin/pc_query -m %s"
 
 The current version features experimental write support. If you want to
 test this, first make sure **you have a backup of your data** (but please do

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -20,7 +20,7 @@ that query_command uses pc_query:
 
 Example from .muttrc::
 
-        set query_command="/home/username/bin/pc_query -m '%s'"
+        set query_command="/home/username/bin/pc_query -m %s"
 
 The current version features experimental write support. If you want to
 test this, first make sure **you have a backup of your data** (but please do


### PR DESCRIPTION
mutt will quote the %s on its own and if you do this additionally you can get something like that:

`To: <some where>sh: 1: cannot open some: No such file`
