### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ for how to use these and for some more options.
 
 *pycarddav* can be configured to use different CardDAV accounts, see the example
 config for details. An account can be specified with *-a account_name* with all
-three utilies. If no account is chosen all searching and syncing actions will
+three utilities. If no account is chosen all searching and syncing actions will
 use all configured accounts, while on adding cards the first configured account
 will be used.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -38,7 +38,7 @@ for how to use these and for some more options.
 
 *pycarddav* can be configured to use different CardDAV accounts, see the example
 config for details. An account can be specified with *-a account_name* with all
-three utilies. If no account is chosen all searching and syncing actions will
+three utilities. If no account is chosen all searching and syncing actions will
 use all configured accounts, while on adding cards the first configured account
 will be used.
 

--- a/pycarddav/__init__.py
+++ b/pycarddav/__init__.py
@@ -262,7 +262,7 @@ class ConfigurationParser(object):
         validity of the common configuration values. It returns True
         on success, False otherwise.
 
-        This function can be overriden to augment the checks or the
+        This function can be overridden to augment the checks or the
         configuration tweaks achieved before the parsing function
         returns.
         """
@@ -397,7 +397,7 @@ class ConfigurationParser(object):
 
         First, data declared in the configuration schema are extracted
         from the configuration file, with type checking and possibly
-        through a filter. Then these data are completed or overriden
+        through a filter. Then these data are completed or overridden
         using the values read from the command line.
         """
         items = {}

--- a/pycarddav/backend.py
+++ b/pycarddav/backend.py
@@ -40,8 +40,8 @@ account:
 $ACCOUNTNAME_r:   # as in resource
     href (TEXT)
     etag (TEXT)
-    name (TEXT): name as in vcard, seperated by ';'
-    fname (TEXT): formated name
+    name (TEXT): name as in vcard, separated by ';'
+    fname (TEXT): formatted name
     status (INT): status of this card, see below for meaning
     vcard (TEXT): the actual vcard
 

--- a/pycarddav/controllers/sync.py
+++ b/pycarddav/controllers/sync.py
@@ -34,7 +34,7 @@ __all__ = ['sync']
 
 
 def sync(conf):
-    """this should probably be seperated from the class definitions"""
+    """this should probably be separated from the class definitions"""
 
     syncer = carddav.PyCardDAV(conf.account.resource,
                                user=conf.account.user,

--- a/pycarddav/model.py
+++ b/pycarddav/model.py
@@ -35,10 +35,10 @@ import vobject
 
 
 def list_clean(string):
-    """ transforms a comma seperated string to a list, stripping whitespaces
+    """ transforms a comma separated string to a list, stripping whitespaces
     "HOME, WORK,pref" -> ['HOME', 'WORK', 'pref']
 
-    string: string of comma seperated elements
+    string: string of comma separated elements
     returns: list()
     """
 
@@ -286,7 +286,7 @@ class VCard(defaultdict):
         """serialize to VCARD as specified in RFC2426,
         if no UID is specified yet, one will be added (as a UID is mandatory
         for carddav as specified in RFC6352
-        TODO make shure this random uid is unique"""
+        TODO make sure this random uid is unique"""
         import string
         import random
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- doc/usage.rst
- pycarddav/__init__.py
- pycarddav/backend.py
- pycarddav/controllers/sync.py
- pycarddav/model.py

Fixes:
- Should read `separated` rather than `seperated`.
- Should read `utilities` rather than `utilies`.
- Should read `overridden` rather than `overriden`.
- Should read `sure` rather than `shure`.
- Should read `formatted` rather than `formated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md